### PR TITLE
Remove unneeded type attribute in select

### DIFF
--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -47,7 +47,6 @@
                                                         text = 'lsmb_dbadmin'},
                                                     { value = 'postgres',
                                                     text  = 'postgres'} ]
-                                        type = 'text'
                                         size = '15'
                                         class = 'username'
                                         tabindex = 1


### PR DESCRIPTION
Vue warns on attributes which have no setters